### PR TITLE
Fix to code that reconstructs full sigma from solver.sigma_ for sklearn ARD

### DIFF
--- a/ACEHAL/fit.py
+++ b/ACEHAL/fit.py
@@ -315,23 +315,22 @@ def do_fit(Psi, Y, B, E0s, solver, n_committee=8, basis_normalization=None, pot_
     if n_committee > 0:
         sigma = solver.sigma_
 
-        # ARD solver returns sigma only for selected features, but does not indicate which.
-        # Reconstruct full signa, hoping that coeff == 0 implies feature was removed by ARD
+        # sklearn ARDRegression solver returns sigma only for selected features, but does not explicitly
+        # indicate which ones those are.
         if sigma.shape[0] != len(c_norm):
-            # make sure sizes match
-            assert sigma.shape[0] == sum(np.nonzero(c_norm))
+            # only valid for sklearn ARDRegression
+            included_c = solver.lambda_ < solver.lambda_threshold
+            assert sigma.shape[0] == sum(included_c)
 
-            sigma = np.zeros((len(c_norm), len(c_norm)), dtype=float)
-            for (i, non_zero) in enumerate(np.nonzero(c_norm)):
-                coeff = solver.sigma_[i, i]
-                sigma[non_zero, non_zero] = coeff
-
+            sigma_full = np.zeros((len(c_norm), len(c_norm)), dtype=sigma.dtype)
+            sigma_full[included_c, included_c] = sigma
+            sigma = sigma_full
     else:
         sigma = None
 
     # create committee coefficients
     if n_committee > 0:
-        # make sure that raw coefficients (c_norm) are used, since sigma is scaled to be
+        # make sure that raw coefficients (c_norm) are used, since sigma is still scaled to be
         # consistent with those, and unscale resulting committee coefficients below
         if rng is None:
             comms = np.random.multivariate_normal(c_norm, sigma, size=n_committee)


### PR DESCRIPTION
Use `solver.lambda_ < lambda_threshold` to determine which features were actually included in `solver.sigma_` to more reliably reconstruct full (all features) sigma.